### PR TITLE
chore: renaming requirement.txt into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi[standard]
+pydantic
+sqlalchemy
+psycopg[binary]
+alembic
+python-dotenv
+email-validator


### PR DESCRIPTION
naming mistake